### PR TITLE
add support for debian build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 VERSION := $(shell git describe --tags --exact-match 2>/dev/null || echo latest)
-DOCKERHUB_NAMESPACE ?= ehealthafrica
+DOCKERHUB_NAMESPACE ?= hazeltek
 IMAGE := ${DOCKERHUB_NAMESPACE}/ckan:${VERSION}-alpine
 
 build:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 VERSION := $(shell git describe --tags --exact-match 2>/dev/null || echo latest)
-DOCKERHUB_NAMESPACE ?= keitaro
-IMAGE := ${DOCKERHUB_NAMESPACE}/ckan:${VERSION}
+DOCKERHUB_NAMESPACE ?= ehealthafrica
+IMAGE := ${DOCKERHUB_NAMESPACE}/ckan:${VERSION}-alpine
 
 build:
 	docker build -t ${IMAGE} rootfs

--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,8 @@ IMAGE := ${DOCKERHUB_NAMESPACE}/ckan:${VERSION}-alpine
 build:
 	docker build -t ${IMAGE} rootfs
 
+build-no-cache:
+	docker build --no-cache -t ${IMAGE} rootfs
+
 push: build
 	docker push ${IMAGE}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 VERSION := $(shell git describe --tags --exact-match 2>/dev/null || echo latest)
-DOCKERHUB_NAMESPACE ?= hazeltek
+DOCKERHUB_NAMESPACE ?= ehealthafrica
 IMAGE := ${DOCKERHUB_NAMESPACE}/ckan:${VERSION}-alpine
 
 build:

--- a/README.md
+++ b/README.md
@@ -2,20 +2,22 @@
 
 ## Overview
 
-This repository contains base docker image used to build CKAN instances. It's based on [Alpine Linux](https://alpinelinux.org/) and includes only required extensions to start CKAN instance.
+This repository contains the necessary files for building a base docker image for CKAN. The build can target either [Alpine Linux](https://alpinelinux.org/) or [Debian Linux](https//debian.org) and only includes required extensions to start a CKAN instance. This is based-off Keitaro's [docker-ckan](https://github.com/keitaroinc/docker-ckan).
 
 ## Build
 
 To create new image run:
 
-```sh 
-docker build --tag ckan-2.8.2 . 
-``` 
+```sh
+docker build --tag ckan-2.8.2 .
+```
+
 The –-tag ckan-2.8.2 flag sets the image name to ckan-2.8.2 and the dot ( “.” ) at the end tells docker build to look into the current directory for Dockerfile and related contents.
 
 ## List
 
 Check if the image shows up in the list of images:
+
 ```sh
  docker images
 ```
@@ -23,26 +25,28 @@ Check if the image shows up in the list of images:
 ## Run
 
 To start and test newly created image run:
+
 ```sh
  docker run ckan-2.8.2
 ```
-Check if CKAN was succesfuly started on http://localhost:5000. The ckan site url is configured in ENV CKAN_SITE_URL.
 
+Check if CKAN was succesfuly started on <http://localhost:5000>. The ckan site url is configured in ENV CKAN_SITE_URL.
 
 ## Upload to DockerHub
 
->*It's recommended to upload built images to DockerHub* 
+>*It's recommended to upload built images to DockerHub*
 
 To upload the image to DockerHub run:
 
-```sh 
-docker push [options] <docker-hub>/ckan:<image-tag> 
+```sh
+docker push [options] <docker-hub>/ckan:<image-tag>
 ```
 
-## Upgrade 
+## Upgrade
+
 To upgrade the Docker file to use new CKAN version, in the Dockerfile you should change:
 
->ENV GIT_BRANCH={ckan_release} 
+> ENV GIT_BRANCH={ckan_release}
 
 Check [CKAN repository](https://github.com/ckan/ckan/releases) for the latest releases. 
 If there are new libraries used by the new version requirements, those needs to be included too.
@@ -51,7 +55,7 @@ If there are new libraries used by the new version requirements, those needs to 
 
 Default extensions used in the Dockerfile  are kept in:
 
->ENV CKAN__PLUGINS envvars image_view text_view recline_view datastore datapusher
+> ENV CKAN__PLUGINS envvars image_view text_view recline_view datastore datapusher
 
 ## Add new scripts
 

--- a/README.md
+++ b/README.md
@@ -4,15 +4,31 @@
 
 This repository contains the necessary files for building a base docker image for CKAN. The build can target either [Alpine Linux](https://alpinelinux.org/) or [Debian Linux](https//debian.org) and only includes required extensions to start a CKAN instance. This is based-off Keitaro's [docker-ckan](https://github.com/keitaroinc/docker-ckan).
 
+> **NOTE**  
+> The `master` branch tracks and absorbs changes from the upstream Keitaro repository which then goes into the `develop` branch. The `develop` contains our modifications to the original work done by Keitaro mostly to include support for building a Debian Linux based CKAN image. The Debian build is modelled after the original Alpine build, to ensure the same build and runtime mechanisms apply across the targetted distros.
+>
+> Modifications should be done with care in order not to deviate too much from the source and thereby hamper the "pulling and merging" of improvements from the upstream repository.
+
 ## Build
 
-To create new image run:
+To create a new image, use the `build.sh` bash script. Here is a usage description gotten from `./build.sh --help`:
 
 ```sh
-docker build --tag ckan-2.8.2 .
+Build Alpine or Debian based CKAN image
+
+Usage:
+  ./build.sh [options]
+
+Options:
+  --deb         | -d      build Debain image.
+  --dry-run               performs a dry-run to show configs.
+  --help        | -h      show this message.
+  --namespace             docker hub account name.
+  --no-cache              build image without using cache.
+  --tag         | -t      the image tag.
 ```
 
-The –-tag ckan-2.8.2 flag sets the image name to ckan-2.8.2 and the dot ( “.” ) at the end tells docker build to look into the current directory for Dockerfile and related contents.
+The script is configured to build an `Alpine` image by default (except when `--deb` flag is provided). The built image is named in the form `<namespace>/ckan` and tagged with the latest tag for the repository or "latest" if there is none (or uses value from `--tag <ckan-version>` option if provided). The resulting full image name becomes `<namespace>/ckan:<tag>-alpine` for Alpine or just `<namespace>/ckan:<tag>` for a Debian image. For instance: `ehealthafrica/ckan:2.7.8-alpine`.
 
 ## List
 
@@ -27,14 +43,14 @@ Check if the image shows up in the list of images:
 To start and test newly created image run:
 
 ```sh
- docker run ckan-2.8.2
+ docker run <namespace>/ckan:<image-tag>
 ```
 
 Check if CKAN was succesfuly started on <http://localhost:5000>. The ckan site url is configured in ENV CKAN_SITE_URL.
 
 ## Upload to DockerHub
 
->*It's recommended to upload built images to DockerHub*
+> *It's recommended to upload built images to DockerHub*
 
 To upload the image to DockerHub run:
 
@@ -44,7 +60,7 @@ docker push [options] <docker-hub>/ckan:<image-tag>
 
 ## Upgrade
 
-To upgrade the Docker file to use new CKAN version, in the Dockerfile you should change:
+To upgrade the Docker files to use new CKAN version, in the Dockerfiles you should change:
 
 > ENV GIT_BRANCH={ckan_release}
 

--- a/build.sh
+++ b/build.sh
@@ -14,16 +14,16 @@ function show_help {
     --help        | -h      show this message.
     --namespace             docker hub account name.
     --no-cache              build image without using cache.
-    --version     | -v      version number to tag with.
+    --tag         | -t      the image tag.
   """
 }
 
 function _build_image_name {
   local deb=$1
   local namespace=$2
-  local version=$3
+  local tag=$3
 
-  local image_name="${namespace}/ckan:${version}"
+  local image_name="${namespace}/ckan:${tag}"
   if [[ ${deb} = "no" ]]; then
     image_name="${image_name}-alpine"
   fi
@@ -85,7 +85,7 @@ while [[ $# -gt 0 ]]; do
       exit 0
     ;;
 
-    -v | --version )
+    -t | --tag )
       shift
       version=$1
       shift
@@ -97,7 +97,7 @@ done
 _build_image_name ${deb} ${namespace} ${version}
 
 if [[ $dry_run = "yes" ]]; then
-  echo "deb=${deb} namespace=${namespace} version=${version}"
+  echo "deb=${deb} namespace=${namespace} tag=${version}"
   echo ${result}
 else
   build ${deb} ${result} ${nocache}

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+function show_help {
+  echo """
+  Build Alpine or Debian Based CKAN Image
+
+  Usage:
+    ./build.sh [options]
+
+  Options:
+    --deb         | -d      build Debain image.
+    --dry-run               performs a dry-run to show configs.
+    --help        | -h      show this message.
+    --namespace             docker hub account name.
+    --no-cache              build image without using cache.
+    --version     | -v      version number to tag with.
+  """
+}
+
+function _build_image_name {
+  local deb=$1
+  local namespace=$2
+  local version=$3
+
+  local image_name="${namespace}/ckan:${version}"
+  if [[ ${deb} = "no" ]]; then
+    image_name="${image_name}-alpine"
+  fi
+
+  result=${image_name}
+}
+
+function build {
+  local deb=$1
+  local image_name=$2
+  local nocache=$3
+  local filename=Dockerfile
+
+  if [[ ${deb} = "yes" ]]; then
+    filename=Dockerfile.deb
+  fi
+
+  echo ">> Building CKAN Image '${image_name}' (using ${filename}) ..."
+  echo ""
+
+  if [[ ${nocache} = "yes" ]]; then
+    docker build -f rootfs/${filename} -t ${image_name} rootfs
+  else
+    docker build --no-cache -f rootfs/${filename} -t ${image_name} rootfs
+  fi
+}
+
+deb=no
+dry_run=no
+nocache=no
+namespace=${DOCKERHUB_NAMESPACE:=hazeltek}
+version=$(git describe --tags --exact-match 2>/dev/null || echo latest)
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -d | --deb )
+      deb=yes
+      shift
+    ;;
+
+    --dry-run )
+      dry_run=yes
+      shift
+    ;;
+
+    --namespace )
+      shift
+      namespace=$1
+      shift
+    ;;
+
+    --no-cache )
+      nocache=yes
+      shift
+    ;;
+
+    -h | --help )
+      show_help
+      exit 0
+    ;;
+
+    -v | --version )
+      shift
+      version=$1
+      shift
+    ;;
+  esac
+done
+
+# build image name which is stored in global var: result
+_build_image_name ${deb} ${namespace} ${version}
+
+if [[ $dry_run = "yes" ]]; then
+  echo "deb=${deb} namespace=${namespace} version=${version}"
+  echo ${result}
+else
+  build ${deb} ${result} ${nocache}
+fi

--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,7 @@ set -Eeuo pipefail
 
 function show_help {
   echo """
-  Build Alpine or Debian Based CKAN Image
+  Build Alpine or Debian based CKAN image
 
   Usage:
     ./build.sh [options]

--- a/build.sh
+++ b/build.sh
@@ -54,7 +54,7 @@ function build {
 deb=no
 dry_run=no
 nocache=no
-namespace=${DOCKERHUB_NAMESPACE:=hazeltek}
+namespace=${DOCKERHUB_NAMESPACE:=ehealthafrica}
 version=$(git describe --tags --exact-match 2>/dev/null || echo latest)
 
 while [[ $# -gt 0 ]]; do

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,7 +1,7 @@
 ##################
 ### Build CKAN ###
 ##################
-FROM alpine:3.8 as ckanbuild
+FROM alpine:3.11 as ckanbuild
 
 # Set CKAN version to build
 ENV GIT_URL=https://github.com/ckan/ckan.git
@@ -48,7 +48,7 @@ RUN pip wheel --wheel-dir=/wheels uwsgi gevent
 ############
 ### MAIN ###
 ############
-FROM alpine:3.8
+FROM alpine:3.11
 
 MAINTAINER Keitaro Inc <info@keitaro.com>
 

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -5,7 +5,7 @@ FROM alpine:3.8 as ckanbuild
 
 # Set CKAN version to build
 ENV GIT_URL=https://github.com/ckan/ckan.git
-ENV GIT_BRANCH=ckan-2.8.2
+ENV GIT_BRANCH=ckan-2.8.4
 
 # Set src dirs
 ENV SRC_DIR=/srv/app/src
@@ -26,6 +26,7 @@ RUN apk add --no-cache \
         autoconf \
         automake \
         libtool \
+        libffi-dev \
         musl-dev \
         pcre-dev \
         pcre \

--- a/rootfs/Dockerfile.deb
+++ b/rootfs/Dockerfile.deb
@@ -1,0 +1,159 @@
+##########################
+## Build CKAN :: DEBIAN ##
+##########################
+FROM debian:buster-slim as ckanbuild
+
+# Set CKAN version to build
+ENV GIT_URL=https://github.com/ckan/ckan.git
+ENV GIT_BRANCH=ckan-2.8.4
+
+# Set src dirs
+ENV SRC_DIR=/srv/app/src
+ENV PIP_SRC=${SRC_DIR}
+
+WORKDIR ${SRC_DIR}
+
+# Packages to build CKAN requirements and plugins
+RUN apt-get -q -y update \
+    && DEBIAN_FRONTEND=noninteractive apt-get -q -y upgrade \
+    && apt-get -q -y install \
+       python-dev \
+       python-pip \
+       python-wheel \
+       libpq-dev \
+       libxml2-dev \
+       libxslt-dev \
+       libssl-dev \
+       libffi-dev \
+       libpcre3-dev \
+       libpcre3 \
+       git-core \
+       build-essential \
+    && apt-get -q clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create the src directory
+RUN mkdir -p ${SRC_DIR}
+
+# Fetch and build CKAN and requirements
+RUN pip install -e git+${GIT_URL}@${GIT_BRANCH}#egg=ckan
+RUN rm -rf ${SRC_DIR}/ckan/.git
+RUN pip wheel --wheel-dir=/wheels -r ckan/requirements.txt
+RUN pip wheel --wheel-dir=/wheels uwsgi gevent
+
+
+###########################
+### Default-Extensions ####
+###########################
+FROM debian:buster-slim as extbuild
+
+# Set src dirs
+ENV SRC_DIR=/srv/app/src
+ENV PIP_SRC=${SRC_DIR}
+
+# List of default extensions
+ENV DEFAULT_EXTENSIONS envvars s3filestore
+
+# Locations and tags, please use specific tags or revisions
+ENV ENVVARS_GIT_URL=https://github.com/okfn/ckanext-envvars
+ENV ENVVARS_GIT_BRANCH=0.0.1
+ENV S3FILESTORE_GIT_URL=https://github.com/okfn/ckanext-s3filestore
+ENV S3FILESTORE_GIT_BRANCH=33d4b60
+
+RUN apt-get -q -y update \
+    && DEBIAN_FRONTEND=noninteractive apt-get -q -y upgrade \
+    && apt-get -q -y install \
+       git \
+       curl \
+       python \
+       python-dev \
+       python-pip
+
+# Create the src directory
+RUN mkdir -p ${SRC_DIR}
+
+# Fetch and build the default CKAN extensions
+RUN pip wheel --wheel-dir=/wheels git+${ENVVARS_GIT_URL}@${ENVVARS_GIT_BRANCH}#egg=ckanext-envvars
+RUN pip wheel --wheel-dir=/wheels git+${S3FILESTORE_GIT_URL}@${S3FILESTORE_GIT_BRANCH}#egg=ckanext-s3filestore
+RUN pip wheel --wheel-dir=/wheels -r https://raw.githubusercontent.com/okfn/ckanext-s3filestore/${S3FILESTORE_GIT_BRANCH}/requirements.txt
+RUN curl -o /wheels/s3filestore.txt https://raw.githubusercontent.com/okfn/ckanext-s3filestore/${S3FILESTORE_GIT_BRANCH}/requirements.txt
+
+
+################
+## Build Main ##
+################
+FROM debian:buster-slim
+LABEL MAINTAINER="Abdul-Hakeem Shaibu <s.abdulhakeeem@gmail.com>"
+
+ENV APP_DIR=/srv/app
+ENV SRC_DIR=/srv/app/src
+ENV PIP_SRC=${SRC_DIR}
+ENV CKAN_SITE_URL=http://localhost:5000
+ENV CKAN__PLUGINS envvars s3filestore image_view text_view recline_view datastore datapusher
+
+WORKDIR ${APP_DIR}
+
+# Install ncessary packages to run CKAN
+RUN apt-get -q -y update \
+    && DEBIAN_FRONTEND=noninteractive apt-get -q -y upgrade \
+    && apt-get -q -y install \
+       gettext \
+       curl \
+       postgresql-client && \
+       python \
+       python-pip \
+       libmagic1 \
+       libpcre3 \
+       libxslt \
+       libxml2 \
+    # Create SRC_DIR
+    mkdir -p ${SRC_DIR}
+
+# Get artifacts from build stages
+COPY --from=ckanbuild /wheels /srv/app/wheels
+COPY --from=extbuild /wheels /srv/app/ext_wheels
+COPY --from=ckanbuild /srv/app/src/ckan /srv/app/src/ckan
+
+# Copy necessary scripts
+COPY setup/app ${APP_DIR}
+
+# Additional install steps for build stages artifacts
+RUN pip install --no-index --find-links=/srv/app/wheels uwsgi gevent
+
+# Create a local user and group to run the app
+RUN groupadd --gid 92 --system ckan && \
+    useradd --uid 92 --home-dir /srv/app --gid ckan ckan
+
+# Install CKAN
+RUN pip install -e /srv/app/src/ckan && \
+    cd ${SRC_DIR}/ckan && \
+    cp who.ini ${APP_DIR} && \
+    pip install --no-index --find-links=/srv/app/wheels -r requirements.txt && \
+    # Install default CKAN extensions
+    pip install --no-index --find-links=/srv/app/ext_wheels ckanext-envvars ckanext-s3filestore && \
+    pip install --no-index --find-links=/srv/app/ext_wheels -r /srv/app/ext_wheels/s3filestore.txt && \
+    # Create and update CKAN config
+    # Set timezone
+    echo "UTC" >  /etc/timezone && \
+    # Generate CKAN config
+    paster --plugin=ckan make-config ckan ${APP_DIR}/production.ini && \
+    paster --plugin=ckan config-tool ${APP_DIR}/production.ini "ckan.plugins = ${CKAN__PLUGINS}" && \
+    # Change ownership to app user
+    chown -R ckan:ckan /srv/app
+
+# Remove wheels
+RUN rm -rf /srv/app/wheels /srv/app/ext_wheels
+
+# Copy necessary scripts
+COPY setup/app ${APP_DIR}
+
+# Create entry point directory for children image scripts
+ONBUILD RUN mkdir docker-entrypoint.d
+
+EXPOSE 5000
+
+HEALTHCHECK --interval=10s --timeout=5s --retries=5 CMD curl --fail http://localhost:5000/api/3/action/status_show || exit 1
+
+USER ckan
+
+CMD [ "/srv/app/start_ckan.sh" ]

--- a/rootfs/setup/app/prerun.py
+++ b/rootfs/setup/app/prerun.py
@@ -34,6 +34,7 @@ def check_db_connection(retry=None):
     else:
         connection.close()
 
+
 def check_solr_connection(retry=None):
 
     print '[prerun] Start check_solr_connection...'
@@ -60,6 +61,7 @@ def check_solr_connection(retry=None):
         conn_info = connection.read()
         conn_info = re.sub(r'"zkConnected":true', '"zkConnected":True', conn_info)
         eval(conn_info)
+
 
 def init_db():
 
@@ -169,6 +171,7 @@ def create_sysadmin():
 
         subprocess.call(command)
         print '[prerun] Made user {0} a sysadmin'.format(name)
+
 
 if __name__ == '__main__':
 

--- a/rootfs/setup/app/start_ckan.sh
+++ b/rootfs/setup/app/start_ckan.sh
@@ -35,7 +35,16 @@ then
     fi
   else
     # Start uwsgi
-    uwsgi $UWSGI_OPTS
+    if [ "$CKAN___DEBUG" = true ] || [ "$CKAN___DEBUG" = True ]
+    then
+      ## to use uwsgi in debug mode uncomment next two lines and comment the paster command
+      # UWSGI_OPTS="$UWSGI_OPTS --py-autoreload 2"
+      # uwsgi $UWSGI_OPTS
+
+      paster serve /srv/app/production.ini --reload
+    else
+      uwsgi $UWSGI_OPTS
+    fi
   fi
 else
   echo "[prerun] failed...not starting CKAN."


### PR DESCRIPTION
# Description

Extends the Keitaro setup to include support for building a Debian based CKAN image in addition to the original Alpine image. Ideally targeting just Alpine should be sufficient, however recent attempts to build and install Geospatial libraries (GDAL particularly) proved too difficult and unsuccessful on the Alpine distro, hence the need for Debian.

The README.md file has details on approach taken for the extension.

@tremolo this effectively merges contents from [ckan-docker](https://github.com/eHealthAfrica/ckan-docker.git) into this repository thus ensuring we maintain just a single repository going forward. Furthermore, we are able to track and pull changes from the upstream [Keitaro repository](https://github.com/keitaroinc/docker-ckan.git) into the `master` branch whenever the need arises.

So we can go ahead to drop the [ckan-docker](https://github.com/eHealthAfrica/ckan-docker.git) repository.