### PR TITLE
avoid path issues

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -157,7 +157,7 @@ RUN rm -rf /srv/app/wheels /srv/app/ext_wheels
 COPY setup/app ${APP_DIR}
 
 # Create entrypoint directory for children image scripts
-ONBUILD RUN mkdir /docker-entrypoint.d
+ONBUILD RUN mkdir docker-entrypoint.d
 
 EXPOSE 5000
 

--- a/rootfs/Dockerfile.deb
+++ b/rootfs/Dockerfile.deb
@@ -150,7 +150,7 @@ RUN rm -rf /srv/app/wheels /srv/app/ext_wheels
 COPY setup/app ${APP_DIR}
 
 # Create entry point directory for children image scripts
-ONBUILD RUN mkdir /docker-entrypoint.d
+ONBUILD RUN mkdir docker-entrypoint.d
 
 EXPOSE 5000
 

--- a/rootfs/setup/app/start_ckan.sh
+++ b/rootfs/setup/app/start_ckan.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # Run any startup scripts provided by images extending this one
-if [[ -d "/docker-entrypoint.d" ]]
+if [[ -d "${APP_DIR}/docker-entrypoint.d" ]]
 then
-    for f in /docker-entrypoint.d/*; do
+    for f in ${APP_DIR}/docker-entrypoint.d/*; do
         case "$f" in
             *.sh)     echo "$0: Running init file $f"; . "$f" ;;
             *.py)     echo "$0: Running init file $f"; python "$f"; echo ;;


### PR DESCRIPTION
# Description

Revert to using same path for `docker-entrypoint.d` as used in Keitaro's repository. This is to prevent path mismatch in the future when upstream changes are pulled in and differences in path is not corrected.

## NOTE

Downside to this approach is the immediate need to update the under listed repos to use a a new image with the fix:
- biskit-docker-setup
- eoc-docker-setup
- grid-docker-setup